### PR TITLE
Add ICML 2026 acceptances; fix Chatbots paper title and date

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -193,33 +193,34 @@
 @article{akhtar2026aibenchmarksplateausystematic,
   title = {When AI Benchmarks Plateau: A Systematic Study of Benchmark Saturation},
   author = {Akhtar, Mubashara and Reuel, Anka and Soni, Prajna and Ahuja, Sanchit and Ammanamanchi, Pawan Sasanka and Rawal, Ruchit and Zouhar, Vilem and Yadav, Srishti and Whitehouse, Chenxi and Ki, Dayeon and Mickel, Jennifer and Choshen, Leshem and Suppa, Marek and Batzner, Jan and Chim, Jenny and Sania, Jeba and Long, Yanan and Rahmani, Hossein A. and Knight, Christina and Nan, Yiyang and Raj, Jyoutir and Fan, Yu and Singh, Shubham and Sahoo, Subramanyam and Habba, Eliya and Gohar, Usman and Pawar, Siddhesh and Scholz, Robert and Subramonian, Arjun and Ni, Jingwei and Kochenderfer, Mykel and Koyejo, Sanmi and Sachan, Mrinmaya and Biderman, Stella and Talat, Zeerak and Ghosh, Avijit and Solaiman, Irene},
-  journal = {arXiv preprint arXiv:2602.16763},
+  journal = {International Conference on Machine Learning},
   year = {2026},
-  month = feb,
+  month = jul,
   eprint = {2602.16763},
   archiveprefix = {arXiv},
   primaryclass = {cs.AI},
-  abbr = {Preprint},
+  abbr = {ICML},
   pdf = {https://arxiv.org/pdf/2602.16763}
 }
 @article{bandel2026agenticsystemsshouldbegeneral,
   title = {Position: Agentic Systems Should be General},
   author = {Bandel, Elron and Yehudai, Asaf and Lacoste, Alexandre and Ghosh, Avijit and Neubig, Graham and Mitchell, Margaret and Shmueli-Scheuer, Michal and Choshen, Leshem},
+  journal = {International Conference on Machine Learning},
   year = {2026},
-  month = feb,
-  abbr = {Preprint},
-  note = {Preprint on SSRN},
+  month = jul,
+  abbr = {ICML},
   pdf = {https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6176178}
 }
 @article{reuel2025evaluatesaissocialimpacts,
   title = {Who Evaluates AI's Social Impacts? Mapping Coverage and Gaps in First and Third Party Evaluations},
   author = {Reuel, Anka and Ghosh, Avijit and Chim, Jenny and Tran, Andrew and Long, Yanan and Mickel, Jennifer and Gohar, Usman and Yadav, Srishti and Ammanamanchi, Pawan Sasanka and Allaham, Mowafak and Rahmani, Hossein A. and Akhtar, Mubashara and Friedrich, Felix and Scholz, Robert and Riegler, Michael Alexander and Batzner, Jan and Habba, Eliya and Saxena, Arushi and Kornilova, Anastassia and Wei, Kevin and Soni, Prajna and Mathew, Yohan and Klyman, Kevin and Sania, Jeba and Sahoo, Subramanyam and Bruvik, Olivia Beyer and Sadeghi, Pouya and Goswami, Sujata and Wang, Angelina and Jernite, Yacine and Talat, Zeerak and Biderman, Stella and Kochenderfer, Mykel and Koyejo, Sanmi and Solaiman, Irene},
-  year = {2025},
-  month = nov,
+  journal = {International Conference on Machine Learning},
+  year = {2026},
+  month = jul,
   eprint = {2511.05613},
   archiveprefix = {arXiv},
   primaryclass = {cs.CY},
-  abbr = {Preprint},
+  abbr = {ICML},
   pdf = {https://arxiv.org/pdf/2511.05613}
 }
 @article{casper2025open,
@@ -340,11 +341,11 @@
   pdf = {https://arxiv.org/pdf/2505.00616}
 }
 @article{ghosh2026chatbots,
-  title = {What if AI Systems Weren't Chatbots},
+  title = {What if AI Systems Weren't Chatbots?},
   author = {Ghosh, Sourojit and Venkit, Pranav Narayanan and Gautam, Sanjana and Ghosh, Avijit},
   journal = {ACM Conference on Fairness, Accountability, and Transparency},
   year = {2026},
-  month = may,
+  month = jun,
   abbr = {FAccT},
   pdf = {https://arxiv.org/pdf/2605.07896}
 }

--- a/_news/announcement_70.md
+++ b/_news/announcement_70.md
@@ -1,8 +1,0 @@
----
-layout: post
-date: 2025-11-13 10:00:00-0400
-inline: true
-related_posts: false
----
-
-New paper: [Who Evaluates AI's Social Impacts? Mapping Coverage And Gaps In First And Third Party Evaluations](https://arxiv.org/abs/2511.05613v1). This is the first major output from the Evaluating Evaluations Coalition. We analyzed 186 first-party model release documents and 183 post-release evaluation documents across 7 dimensions of social impact. We find that model developers have become less transparent about their social impact evaluation results over time. This strengthens the case for independent third-party evaluations for AI safety.

--- a/_news/announcement_83.md
+++ b/_news/announcement_83.md
@@ -5,4 +5,4 @@ inline: true
 related_posts: false
 ---
 
-Should all our resources go towards building chatbots? What if we built systems that actually give people meaningful agency? ["What if AI Systems Weren't Chatbots"](https://arxiv.org/abs/2605.07896) is now out as an accepted ACM FAccT paper! Joint work with Sourojit Ghosh, Pranav Narayanan Venkit, and Sanjana Gautam.
+Should all our resources go towards building chatbots? What if we built systems that actually give people meaningful agency? ["What if AI Systems Weren't Chatbots?"](https://arxiv.org/abs/2605.07896) is now out as an accepted ACM FAccT paper! Joint work with Sourojit Ghosh, Pranav Narayanan Venkit, and Sanjana Gautam.

--- a/_news/announcement_84.md
+++ b/_news/announcement_84.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2026-05-12
+inline: true
+related_posts: false
+---
+
+["Who Evaluates AI's Social Impacts? Mapping Coverage and Gaps in First and Third Party Evaluations"](https://arxiv.org/abs/2511.05613) has been accepted to ICML 2026 in Seoul! We analyze 186 first-party model release documents and 248 third-party evaluations across 7 dimensions of social impact, finding that model developers have grown less transparent about social impact evaluation results over time.

--- a/_news/announcement_85.md
+++ b/_news/announcement_85.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2026-05-12
+inline: true
+related_posts: false
+---
+
+["When AI Benchmarks Plateau: A Systematic Study of Benchmark Saturation"](https://arxiv.org/abs/2602.16763) has been accepted to ICML 2026 in Seoul! We systematically study how and when popular AI benchmarks saturate, characterizing the lifecycle of evaluation suites and what saturation patterns reveal about benchmark design.

--- a/_news/announcement_86.md
+++ b/_news/announcement_86.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2026-05-12
+inline: true
+related_posts: false
+---
+
+["Position: Agentic Systems Should be General"](https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6176178) has been accepted to ICML 2026 in Seoul! We argue that agentic systems should be designed as general-purpose collaborators rather than narrow task-specific tools, and lay out what that shift requires from researchers and developers.

--- a/assets/cv.tex
+++ b/assets/cv.tex
@@ -223,7 +223,28 @@
   \resumeSubHeadingListStart
 
         \paper
-        {\href{https://arxiv.org/abs/2605.07896}{What if AI Systems Weren't Chatbots}
+        {\href{https://arxiv.org/abs/2511.05613}{Who Evaluates AI's Social Impacts? Mapping Coverage and Gaps in First and Third Party Evaluations}
+        }
+        {ICML '26}
+        {A. Reuel*, {\bf Avijit Ghosh*}, J. Chim*, A. Tran, Y. Long, J. Mickel, U. Gohar, S. Yadav, P. S. Ammanamanchi, M. Allaham, H. A. Rahmani, M. Akhtar, F. Friedrich, R. Scholz, M. A. Riegler, J. Batzner, E. Habba, A. Saxena, A. Kornilova, K. Wei, P. Soni, Y. Mathew, K. Klyman, J. Sania, S. Sahoo,\newline O. B. Bruvik, P. Sadeghi, S. Goswami, A. Wang, Y. Jernite, Z. Talat, S. Biderman, M. Kochenderfer, S. Koyejo, I. Solaiman}
+        {Seoul, Korea}
+
+        \paper
+        {\href{https://arxiv.org/abs/2602.16763}{When AI Benchmarks Plateau: A Systematic Study of Benchmark Saturation}
+        }
+        {ICML '26}
+        {M. Akhtar, A. Reuel, P. Soni, S. Ahuja, P. S. Ammanamanchi, R. Rawal, V. Zouhar, S. Yadav, C. Whitehouse, D. Ki, J. Mickel, L. Choshen, M. Suppa, J. Batzner, J. Chim, J. Sania, Y. Long, H. A. Rahmani, C. Knight, Y. Nan, J. Raj, Y. Fan, S. Singh, S. Sahoo, E. Habba, U. Gohar, S. Pawar, R. Scholz, A. Subramonian, J. Ni, M. Kochenderfer, S. Koyejo, M. Sachan, S. Biderman, Z. Talat, {\bf Avijit Ghosh}, I. Solaiman}
+        {Seoul, Korea}
+
+        \paper
+        {\href{https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6176178}{Position: Agentic Systems Should be General}
+        }
+        {ICML '26}
+        {E. Bandel, A. Yehudai, A. Lacoste, {\bf Avijit Ghosh}, G. Neubig, M. Mitchell, M. Shmueli-Scheuer, L. Choshen}
+        {Seoul, Korea}
+
+        \paper
+        {\href{https://arxiv.org/abs/2605.07896}{What if AI Systems Weren't Chatbots?}
         }
         {FAccT '26}
         {Sourojit Ghosh*, Pranav Narayanan Venkit, Sanjana Gautam, {\bf Avijit Ghosh*}}
@@ -422,31 +443,10 @@
     \resumeSubHeadingListStart
 
     \paper
-    {\href{https://papers.ssrn.com/sol3/papers.cfm?abstract_id=6176178}{Position: Agentic Systems Should be General}
-    }
-    {Preprint}
-    {E. Bandel, A. Yehudai, A. Lacoste, {\bf Avijit Ghosh}, G. Neubig, M. Mitchell, M. Shmueli-Scheuer, L. Choshen}
-    {}
-
-    \paper
-    {\href{https://arxiv.org/abs/2602.16763}{When AI Benchmarks Plateau: A Systematic Study of Benchmark Saturation}
-    }
-    {Preprint}
-    {M. Akhtar, A. Reuel, P. Soni, S. Ahuja, P. S. Ammanamanchi, R. Rawal, V. Zouhar, S. Yadav, C. Whitehouse, D. Ki, J. Mickel, L. Choshen, M. Suppa, J. Batzner, J. Chim, J. Sania, Y. Long, H. A. Rahmani, C. Knight, Y. Nan, J. Raj, Y. Fan, S. Singh, S. Sahoo, E. Habba, U. Gohar, S. Pawar, R. Scholz, A. Subramonian, J. Ni, M. Kochenderfer, S. Koyejo, M. Sachan, S. Biderman, Z. Talat, {\bf Avijit Ghosh}, I. Solaiman}
-    {}
-
-    \paper
     {\href{https://www.dataprovenance.org/economies-of-open-intelligence.pdf}{Economies of Open Intelligence: Tracing Power \& Participation in the Model Ecosystem}
     }
     {Preprint}
     {S. Longpre, C. Akiki, C. Lund, A. Kulkarni, E. Chen, I. Solaiman, {\bf Avijit Ghosh}, Y. Jernite, L. Kaffee}
-    {}
-
-    \paper
-    {\href{https://arxiv.org/abs/2511.05613}{Who Measures What Matters? An Analysis of Social Impact Evaluations in Foundation Model Reporting}
-    }
-    {Preprint}
-    {A. Reuel*, {\bf Avijit Ghosh*}, J. Chim*, A. Tran, Y. Long, J. Mickel, U. Gohar, S. Yadav, P. S. Ammanamanchi, M. Allaham, H. A. Rahmani, M. Akhtar, F. Friedrich, R. Scholz, M. A. Riegler, J. Batzner, E. Habba, A. Saxena, A. Kornilova, K. Wei, P. Soni, Y. Mathew, K. Klyman, J. Sania, S. Sahoo,\newline O. B. Bruvik, A. Wang, S. Goswami, P. Sadeghi, Y. Jernite, Z. Talat, S. Biderman, M. Kochenderfer, S. Koyejo, I. Solaiman}
     {}
 
     \paper


### PR DESCRIPTION
## Summary
- Promote three papers (Who Evaluates AI's Social Impacts, When AI Benchmarks Plateau, Position: Agentic Systems Should be General) from Preprint to **ICML 2026** in [papers.bib](_bibliography/papers.bib) and [cv.tex](assets/cv.tex)
- Add news items for the three ICML acceptances ([84](_news/announcement_84.md), [85](_news/announcement_85.md), [86](_news/announcement_86.md))
- Remove superseded "Who Evaluates" preprint announcement
- Fix missing `?` on "What if AI Systems Weren't Chatbots?" and bump its month from May → June 2026

## Test plan
- [ ] Jekyll builds without errors
- [ ] LaTeX builds without errors
- [ ] Papers tab renders the three new ICML entries and the corrected Chatbots title
- [ ] News feed shows the three ICML acceptance items and no longer shows the old Who Evaluates preprint item