### PR TITLE
Add ICML 2026 TAIGR workshop paper acceptance

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -358,3 +358,12 @@
   abbr = {EvalEval},
   pdf = {https://openreview.net/pdf?id=SqxApLlGP9}
 }
+@article{ghosh2026intelligencebottleneck,
+  title = {Intelligence Is Not the Bottleneck: Structural Barriers to Automating Alignment Research},
+  author = {Ghosh, Avijit},
+  journal = {TAIGR Workshop at the International Conference on Machine Learning},
+  year = {2026},
+  month = jul,
+  abbr = {TAIGR},
+  pdf = {https://openreview.net/forum?id=2ToECBOs50}
+}

--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -360,7 +360,7 @@
 }
 @article{ghosh2026intelligencebottleneck,
   title = {Intelligence Is Not the Bottleneck: Structural Barriers to Automating Alignment Research},
-  author = {Ghosh, Avijit},
+  author = {Kierans, Aidan and Casper, Stephen and Ghosh, Avijit},
   journal = {TAIGR Workshop at the International Conference on Machine Learning},
   year = {2026},
   month = jul,

--- a/_news/announcement_89.md
+++ b/_news/announcement_89.md
@@ -1,0 +1,8 @@
+---
+layout: post
+date: 2026-05-17
+inline: true
+related_posts: false
+---
+
+["Intelligence Is Not the Bottleneck: Structural Barriers to Automating Alignment Research"](https://openreview.net/forum?id=2ToECBOs50) has been accepted as a poster to the [TAIGR Workshop at ICML 2026](https://openreview.net/forum?id=2ToECBOs50) in Seoul!

--- a/_news/announcement_89.md
+++ b/_news/announcement_89.md
@@ -5,4 +5,4 @@ inline: true
 related_posts: false
 ---
 
-["Intelligence Is Not the Bottleneck: Structural Barriers to Automating Alignment Research"](https://openreview.net/forum?id=2ToECBOs50) has been accepted as a poster to the [TAIGR Workshop at ICML 2026](https://openreview.net/forum?id=2ToECBOs50) in Seoul!
+["Intelligence Is Not the Bottleneck: Structural Barriers to Automating Alignment Research"](https://openreview.net/forum?id=2ToECBOs50) (with Aidan Kierans and Stephen Casper) has been accepted as a poster to the [TAIGR Workshop at ICML 2026](https://openreview.net/forum?id=2ToECBOs50) in Seoul! We argue that structural barriers — not intelligence — are the principal bottleneck to meaningful automated alignment research, and that no realistic amount of automation will reduce catastrophic risks without substantial institutional progress.

--- a/assets/cv.tex
+++ b/assets/cv.tex
@@ -540,7 +540,7 @@
         {\href{https://openreview.net/forum?id=2ToECBOs50}{Intelligence Is Not the Bottleneck: Structural Barriers to Automating Alignment Research}
         }
         {TAIGR '26}
-        {{\bf Avijit Ghosh}}
+        {Aidan Kierans, Stephen Casper, {\bf Avijit Ghosh}}
         {Seoul, KR}
 
     \paper

--- a/assets/cv.tex
+++ b/assets/cv.tex
@@ -537,6 +537,13 @@
     \resumeSubHeadingListStart
 
     \paper
+        {\href{https://openreview.net/forum?id=2ToECBOs50}{Intelligence Is Not the Bottleneck: Structural Barriers to Automating Alignment Research}
+        }
+        {TAIGR '26}
+        {{\bf Avijit Ghosh}}
+        {Seoul, KR}
+
+    \paper
         {\href{https://openreview.net/forum?id=SqxApLlGP9}{Position: Evaluations of AI Moral Reasoning Still Miss Half of the Picture}
         }
         {EvalEval '26}


### PR DESCRIPTION
"Intelligence Is Not the Bottleneck: Structural Barriers to Automating Alignment Research" accepted as poster to TAIGR Workshop at ICML 2026. Updated news, papers.bib, and CV.

https://claude.ai/code/session_01NW15XW4eJn5AkDMx3ZuRx5