### PR TITLE
Remove em dashes from TAIGR news announcement

### DIFF
--- a/_news/announcement_89.md
+++ b/_news/announcement_89.md
@@ -5,4 +5,4 @@ inline: true
 related_posts: false
 ---
 
-["Intelligence Is Not the Bottleneck: Structural Barriers to Automating Alignment Research"](https://openreview.net/forum?id=2ToECBOs50) (with Aidan Kierans and Stephen Casper) has been accepted as a poster to the [TAIGR Workshop at ICML 2026](https://openreview.net/forum?id=2ToECBOs50) in Seoul! We argue that structural barriers — not intelligence — are the principal bottleneck to meaningful automated alignment research, and that no realistic amount of automation will reduce catastrophic risks without substantial institutional progress.
+["Intelligence Is Not the Bottleneck: Structural Barriers to Automating Alignment Research"](https://openreview.net/forum?id=2ToECBOs50) (with Aidan Kierans and Stephen Casper) has been accepted as a poster to the [TAIGR Workshop at ICML 2026](https://openreview.net/forum?id=2ToECBOs50) in Seoul! We argue that structural barriers, not intelligence, are the principal bottleneck to meaningful automated alignment research, and that no realistic amount of automation will reduce catastrophic risks without substantial institutional progress.


### PR DESCRIPTION
Replaces `— not intelligence —` with `, not intelligence,` in `_news/announcement_89.md`.

https://claude.ai/code/session_01NW15XW4eJn5AkDMx3ZuRx5

---
_Generated by [Claude Code](https://claude.ai/code/session_01NW15XW4eJn5AkDMx3ZuRx5)_