### PR TITLE
Improve mobile news section: show 3 items + half-visible 4th

### DIFF
--- a/_includes/news.html
+++ b/_includes/news.html
@@ -2,7 +2,7 @@
           <div class="news">
             {% if site.news != blank -%} 
             {%- assign news_size = site.news | size -%}
-            <div class="table-responsive" {% if site.news_scrollable and news_size > 3 %}style="max-height: 45vw"{% endif %}>
+            <div class="table-responsive" id="news-scroll" {% if site.news_scrollable and news_size > 3 %}style="max-height: 45vw"{% endif %}>
               <table class="table table-sm table-borderless">
               {%- assign news = site.news | reverse -%}
               {% if site.news_limit %}

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -299,6 +299,14 @@ body.sticky-bottom-footer {
 
 @media (max-width: 576px) {
   .news {
+    .table-responsive {
+      // Overrides inline max-height: 45vw which is too short on mobile;
+      // JS replaces this with the exact height for 3 items + half of the 4th.
+      max-height: 65vw !important;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+
     table,
     tbody {
       display: block;

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -1,3 +1,20 @@
+function adjustMobileNewsHeight() {
+    if ($(window).width() > 576) return;
+    var $container = $('#news-scroll');
+    if (!$container.length) return;
+    var $rows = $container.find('tr');
+    if ($rows.length < 4) return;
+
+    var height = 0;
+    $rows.slice(0, 3).each(function() {
+        height += $(this).outerHeight(true); // includes margins
+    });
+    // Half the 4th row peeks out to signal more content below
+    height += $rows.eq(3).outerHeight() * 0.5;
+
+    $container.css('max-height', height + 'px');
+}
+
 $(document).ready(function() {
     $('a.abstract').click(function() {
         $(this).parent().parent().find(".abstract.hidden").toggleClass('open');
@@ -8,4 +25,12 @@ $(document).ready(function() {
         $(this).parent().parent().find(".abstract.hidden.open").toggleClass('open');
     });
     $('a').removeClass('waves-effect waves-light');
+
+    adjustMobileNewsHeight();
+});
+
+var newsResizeTimer;
+$(window).on('resize', function() {
+    clearTimeout(newsResizeTimer);
+    newsResizeTimer = setTimeout(adjustMobileNewsHeight, 150);
 });


### PR DESCRIPTION
On mobile the news container showed too few items (sometimes only one),
making it unclear the section was scrollable. This:
- Sets a CSS fallback max-height of 65vw on mobile (overriding the 45vw
  inline style that was too short for stacked block layout)
- Adds overflow-y: auto so the container scrolls
- Adds JS (adjustMobileNewsHeight) that dynamically sets the container
  height to exactly 3 full items + 50% of the 4th, so the cutoff
  signals to users that more content exists below
- Re-runs on window resize to handle orientation changes

https://claude.ai/code/session_01NDtfJQSacuZzWodcvA9gy8