### PR TITLE
Improve mobile news section: show 3 items + half-visible 4th

### DIFF
--- a/_includes/news.html
+++ b/_includes/news.html
@@ -2,7 +2,7 @@
           <div class="news">
             {% if site.news != blank -%} 
             {%- assign news_size = site.news | size -%}
-            <div class="table-responsive" id="news-scroll" {% if site.news_scrollable and news_size > 3 %}style="max-height: 45vw"{% endif %}>
+            <div class="table-responsive{% if site.news_scrollable and news_size > 3 %} news-scrollable{% endif %}" id="news-scroll">
               <table class="table table-sm table-borderless">
               {%- assign news = site.news | reverse -%}
               {% if site.news_limit %}

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -82,6 +82,12 @@ body.sticky-bottom-footer {
   .news-date-badge {
     font-size: 0.74rem;
   }
+
+  .news-scrollable {
+    max-height: 45vw;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
 }
 
 .cv-date-badge {
@@ -299,12 +305,8 @@ body.sticky-bottom-footer {
 
 @media (max-width: 576px) {
   .news {
-    .table-responsive {
-      // Overrides inline max-height: 45vw which is too short on mobile;
-      // JS replaces this with the exact height for 3 items + half of the 4th.
-      max-height: 65vw !important;
-      overflow-y: auto;
-      -webkit-overflow-scrolling: touch;
+    .news-scrollable {
+      max-height: 65vw;
     }
 
     table,

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -1,13 +1,16 @@
 function adjustMobileNewsHeight() {
     if ($(window).width() > 576) return;
     var $container = $('#news-scroll');
-    if (!$container.length) return;
+    if (!$container.hasClass('news-scrollable')) return;
     var $rows = $container.find('tr');
     if ($rows.length < 4) return;
 
+    // Temporarily lift max-height so all rows report their natural height
+    $container.css('max-height', 'none');
+
     var height = 0;
     $rows.slice(0, 3).each(function() {
-        height += $(this).outerHeight(true); // includes margins
+        height += $(this).outerHeight(true); // height + padding + border + margin
     });
     // Half the 4th row peeks out to signal more content below
     height += $rows.eq(3).outerHeight() * 0.5;


### PR DESCRIPTION
## Summary

- Replaces the `style="max-height: 45vw"` inline attribute with a `.news-scrollable` CSS class, so mobile overrides work through normal cascade (no `!important` needed)
- On mobile (≤576px), CSS sets a `65vw` fallback height — enough to show 2–3 items and make the section clearly scrollable
- JS (`adjustMobileNewsHeight`) dynamically sets the container height to exactly 3 full items + 50% of the 4th, so the cutoff visually signals there is more content below; re-runs on resize for orientation changes

## Test plan

- [ ] Open the home page in a mobile browser or Chrome DevTools at ≤375px width
- [ ] News section should show 3 complete items with the 4th partially visible
- [ ] Scrolling down inside the news container should reveal remaining items
- [ ] Rotate to landscape — section should recalculate to still show ~3.5 items
- [ ] Desktop view should be unaffected (news scrolls at `max-height: 45vw` as before)

https://claude.ai/code/session_01NDtfJQSacuZzWodcvA9gy8

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDtfJQSacuZzWodcvA9gy8)_