### PR TITLE
Add FLARE-AI to Papers tab, reorder 2026 publications

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -223,6 +223,43 @@
   abbr = {ICML},
   pdf = {https://arxiv.org/pdf/2511.05613}
 }
+@article{longpre2026flareai,
+  title = {FLARE-AI: Flaw Reporting for AI},
+  author = {Longpre, Shayne and Zhu, Elaine and Ezell, Carson and Ghosh, Avijit and McGregor, Sean and Paeth, Kevin and Klyman, Kevin and Kapoor, Sayash and Bommasani, Rishi and Appel, Ruth and Strom, Gregory and McIlvenny, Lauren and Jaycox, Mark M. and Slattery, Peter and Butters, Nathan and Narayanan, Arvind and Liang, Percy and Pentland, Alex},
+  journal = {International Conference on Machine Learning},
+  year = {2026},
+  month = jul,
+  selected = {true},
+  abbr = {ICML},
+  pdf = {https://arxiv.org/pdf/2606.31567}
+}
+@article{ghosh2026intelligencebottleneck,
+  title = {Intelligence Is Not the Bottleneck: Structural Barriers to Automating Alignment Research},
+  author = {Kierans, Aidan and Casper, Stephen and Ghosh, Avijit},
+  journal = {TAIGR Workshop at the International Conference on Machine Learning},
+  year = {2026},
+  month = jul,
+  abbr = {TAIGR},
+  pdf = {https://openreview.net/forum?id=2ToECBOs50}
+}
+@article{kierans2026moralreasoning,
+  title = {Position: Evaluations of AI Moral Reasoning Still Miss Half of the Picture},
+  author = {Kierans, Aidan and Dutt, Ritam and Rittichier, Kaley and Dori-Hacohen, Shiri and Ghosh, Avijit},
+  journal = {EvalEval Workshop at the Annual Meeting of the Association for Computational Linguistics},
+  year = {2026},
+  month = jul,
+  abbr = {EvalEval},
+  pdf = {https://openreview.net/pdf?id=SqxApLlGP9}
+}
+@article{ghosh2026chatbots,
+  title = {What if AI Systems Weren't Chatbots?},
+  author = {Ghosh, Sourojit and Venkit, Pranav Narayanan and Gautam, Sanjana and Ghosh, Avijit},
+  journal = {ACM Conference on Fairness, Accountability, and Transparency},
+  year = {2026},
+  month = jun,
+  abbr = {FAccT},
+  pdf = {https://arxiv.org/pdf/2605.07896}
+}
 @article{casper2025open,
   title = {Open Technical Problems in Open-Weight AI Model Risk Management},
   author = {Casper, Stephen and O'Brien, Kyle and Longpre, Shayne and Seger, Elizabeth and Klyman, Kevin and Bommasani, Rishi and Nrusimha, Aniruddha and Shumailov, Ilia and Mindermann, S{\"o}ren and Basart, Steven and Rudzicz, Frank and Pelrine, Kellin and Ghosh, Avijit and Strait, Andrew and Kirk, Robert and Hendrycks, Dan and Henderson, Peter and Kolter, J. Zico and Irving, Geoffrey and Gal, Yarin and Bengio, Yoshua and Hadfield-Menell, Dylan},
@@ -232,15 +269,6 @@
   abbr = {TMLR},
   website = {https://openreview.net/forum?id=8QyGLnFkzc}
 }
-@article{kierans2025aligningairequiresautomatingreasoningnorms,
-  title = {Position: Aligning AI Requires Automating Reasoning Norms},
-  author = {Kierans, Aidan and Ghosh, Avijit and Dori-Hacohen, Shiri},
-  year = {2025},
-  month = sep,
-  abbr = {Preprint},
-  note = {Preprint on SSRN},
-  pdf = {https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5399451}
-}
 @article{channing2025ai,
   title = {AI for Scientific Discovery is a Social Problem},
   author = {Channing, Georgia and Ghosh, Avijit},
@@ -249,6 +277,15 @@
   month = mar,
   abbr = {Patterns},
   pdf = {https://www.cell.com/patterns/fulltext/S2666-3899(26)00006-1},
+}
+@article{kierans2025aligningairequiresautomatingreasoningnorms,
+  title = {Position: Aligning AI Requires Automating Reasoning Norms},
+  author = {Kierans, Aidan and Ghosh, Avijit and Dori-Hacohen, Shiri},
+  year = {2025},
+  month = sep,
+  abbr = {Preprint},
+  note = {Preprint on SSRN},
+  pdf = {https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5399451}
 }
 @article{ghosh2025documenting,
   title = {Documenting Patterns of Exoticism of Marginalized Populations within Text-to-Image Generators},

--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -367,3 +367,13 @@
   abbr = {TAIGR},
   pdf = {https://openreview.net/forum?id=2ToECBOs50}
 }
+@article{longpre2026flareai,
+  title = {FLARE-AI: Flaw Reporting for AI},
+  author = {Longpre, Shayne and Zhu, Elaine and Ezell, Carson and Ghosh, Avijit and McGregor, Sean and Paeth, Kevin and Klyman, Kevin and Kapoor, Sayash and Bommasani, Rishi and Appel, Ruth and Strom, Gregory and McIlvenny, Lauren and Jaycox, Mark M. and Slattery, Peter and Butters, Nathan and Narayanan, Arvind and Liang, Percy and Pentland, Alex},
+  journal = {International Conference on Machine Learning},
+  year = {2026},
+  month = jul,
+  selected = {true},
+  abbr = {ICML},
+  pdf = {https://arxiv.org/pdf/2606.31567}
+}


### PR DESCRIPTION
## Summary
- Add the FLARE-AI paper ("FLARE-AI: Flaw Reporting for AI", ICML 2026, arXiv:2606.31567) to `_bibliography/papers.bib` so it renders on the `/papers/` page.
- Reorder the 2026 publications so the 4 ICML papers appear first, followed by TAIGR, EvalEval, FAccT, TMLR, and Patterns (matches jekyll-scholar's `sort_by: year,month` tie-break, which falls back to file order for same year/month).

## Test plan
- [x] Built the site locally with `jekyll build` and verified `/papers/index.html` renders the 2026 entries in the requested order (4 ICML → TAIGR → EvalEval → FAccT → TMLR → Patterns).
- [x] Verified bib file brace balance and entry count via a quick parse check.


---
_Generated by [Claude Code](https://claude.ai/code/session_015uGDuEBv9LTz6H961bCcXx)_